### PR TITLE
get container name from config.json

### DIFF
--- a/logentries.lua
+++ b/logentries.lua
@@ -1,21 +1,38 @@
 require "cjson"
 require "string"
+require "table"
  
+containers = {}
+
 local token = read_config("token")
 
-local msg = {
-    Payload = nil,
-}
-
 function process_message()
+    local differentiator = read_message("Logger") -- sent by 'differentiator' in logentries.toml
+    local container_name = containers[differentiator]
+
     local ok, payload = pcall(cjson.decode, read_message("Payload"))
     if not ok then
-        return -1
+       return -1
     end
 
-    -- msg.Payload = string.format("%s %s %s %s", token, payload.time, read_message("Hostname"), payload.log)
+    if payload.Name then
+       containers[payload.ID] = payload.Name
+       return -2 -- no output, but not error (see https://hekad.readthedocs.org/en/latest/sandbox/index.html#functions-that-must-be-exposed-from-the-lua-sandbox)
+    end
 
-    inject_message(token .. " " .. payload.time .. " " .. read_message("Hostname") .. " " .. payload.log)
+    if not container_name then
+       container_name = "unknown_container"
+    elseif string.find(container_name, "RDAJR") then
+       local split = {}
+       for x in string.gmatch(container_name, "[^.]+") do
+          table.insert(split, x)
+       end
+       container_name = split[2]
+    elseif string.find(container_name, "/") then
+       container_name = string.gsub(container_name, "/", "", 1) -- docker prefixes container name with '/'
+    end
+
+    inject_message(token .. " " .. payload.time .. " name=" .. container_name .. " " .. read_message("Hostname") .. " " .. payload.log)
 
     return 0
 end

--- a/logentries.toml
+++ b/logentries.toml
@@ -4,7 +4,13 @@ log_directory = "/var/lib/docker/containers"
 file_match = '(?P<Container>[^/]+)/[a-zA-Z0-9]+-json.log?(?P<Index>\d+)?(.gz)?'
 priority = ["^Index"]
 differentiator = ["Container"]
- 
+
+[dockerConfig]
+type = "LogstreamerInput"
+log_directory = "/var/lib/docker/containers"
+file_match = '(?P<Container>[^/]+)/config.json'
+differentiator = ["Container"]
+splitter = "NullSplitter"
  
 [logentriesEncoder]
 type = "SandboxEncoder"


### PR DESCRIPTION
Log entries look like this:

```
015-11-23T16:23:07.683251735Z name=nginx2 993a65099d01 172.17.42.1 - - [23/Nov/2015:16:23:07 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.43.0" "-"
2015-11-23T16:23:08.603779448Z name=nginx2 993a65099d01 172.17.42.1 - - [23/Nov/2015:16:23:08 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.43.0" "-"
2015-11-23T16:23:10.275681584Z name=newrelic-trigger_1_0 993a65099d01 172.17.42.1 - - [23/Nov/2015:16:23:10 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.43.0" "-"
2015-11-23T16:23:11.035234125Z name=newrelic-trigger_1_0 993a65099d01 172.17.42.1 - - [23/Nov/2015:16:23:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.43.0" "-"
```

We can then create tags for different services and use those to limit the output.
